### PR TITLE
Update tbui.py

### DIFF
--- a/src/tbui.py
+++ b/src/tbui.py
@@ -343,21 +343,16 @@ class TwixtbotUI():
         self.execute_move(twixt.RESIGN)
 
     def handle_undo(self):
-        if self.game_over():
+        if self.game.result == twixt.RESIGN:
+            self.game.result = None
             return
 
         gl = len(self.game.history)
-
         if gl in self.moves_score:
             del self.moves_score[gl]
 
-        if gl > 0 and gl != 2:
+        if gl > 0:
             self.game.undo()
-        elif gl == 2:
-            # move 2 might be a swap move => reset game and redo move #1
-            move_one = self.game.history[0]
-            self.reset_game()
-            self.execute_move(move_one)
 
         # switch off auto move
         if self.get_current(ct.K_AUTO_MOVE):


### PR DESCRIPTION
- Fixed issue#24 (can't undo resigned game)
- Removed redundant check/delete of move_score dict
- Simplified code to undo second move (which can be swap), because the twixt backend handles this perfectly by itself