### PR TITLE
Hide policy #47

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+share/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/src/backend/board.py
+++ b/src/backend/board.py
@@ -157,14 +157,17 @@ class TwixtBoard:
         nho.objects = objs
         # end set_nn_inputs
 
-    def _create_drawn_peg(self, point, coloridx):
+    def _create_drawn_peg(self, point, coloridx, outline_move=False):
         if coloridx == 1:
-            color = self.stgs.get(ct.K_COLOR[1])
+            color = lcolor = self.stgs.get(ct.K_COLOR[1])
         else:
-            color = self.stgs.get(ct.K_COLOR[2])
+            color = lcolor = self.stgs.get(ct.K_COLOR[2])
+        
+        if outline_move:
+            lcolor = ct.SHOW_LAST_MOVE[1]
 
         peg = self.graph.DrawCircle(self._point_to_coords(
-            point), self.peg_radius, color, color)
+            point), self.peg_radius, color, lcolor, ct.SHOW_LAST_MOVE[2])
         return peg
 
     def create_move_objects(self, game, index):
@@ -183,7 +186,8 @@ class TwixtBoard:
         nho = TBWHistory(move)
         self.history.append(nho)
 
-        nho.objects.append(self._create_drawn_peg(move, color))
+        outline_move = ct.SHOW_LAST_MOVE[0] and index == len(game.history) - 1
+        nho.objects.append(self._create_drawn_peg(move, color, outline_move))
         self.known_moves.add(move)
 
         for dlink in game.DLINKS:

--- a/src/backend/board.py
+++ b/src/backend/board.py
@@ -159,15 +159,12 @@ class TwixtBoard:
 
     def _create_drawn_peg(self, point, coloridx, outline_move=False):
         if coloridx == 1:
-            color = lcolor = self.stgs.get(ct.K_COLOR[1])
+            color = self.stgs.get(ct.K_COLOR[1])
         else:
-            color = lcolor = self.stgs.get(ct.K_COLOR[2])
-        
-        if outline_move:
-            lcolor = ct.SHOW_LAST_MOVE[1]
+            color = self.stgs.get(ct.K_COLOR[2])
 
         peg = self.graph.DrawCircle(self._point_to_coords(
-            point), self.peg_radius, color, lcolor, ct.SHOW_LAST_MOVE[2])
+            point), self.peg_radius, color, color)
         return peg
 
     def create_move_objects(self, game, index):
@@ -186,8 +183,7 @@ class TwixtBoard:
         nho = TBWHistory(move)
         self.history.append(nho)
 
-        outline_move = ct.SHOW_LAST_MOVE[0] and index == len(game.history) - 1
-        nho.objects.append(self._create_drawn_peg(move, color, outline_move))
+        nho.objects.append(self._create_drawn_peg(move, color))
         self.known_moves.add(move)
 
         for dlink in game.DLINKS:

--- a/src/backend/board.py
+++ b/src/backend/board.py
@@ -157,7 +157,7 @@ class TwixtBoard:
         nho.objects = objs
         # end set_nn_inputs
 
-    def _create_drawn_peg(self, point, coloridx, outline_move=False):
+    def _create_drawn_peg(self, point, coloridx):
         if coloridx == 1:
             color = self.stgs.get(ct.K_COLOR[1])
         else:

--- a/src/constants.py
+++ b/src/constants.py
@@ -21,6 +21,7 @@ OUTPUT_TEXT_COLOR = "white"
 COLOR_LIST = ["black", "blue", "cyan", "orange",
               "lightgreen", "purple", "red", "yellow", "white"]
 FIELD_BACKGROUND_COLOR = "lightgrey"
+SHOW_LAST_MOVE = [True, 'yellow', 2]  # bool: show/don't show, border color, border size
 
 
 HEATMAP_CIRCLE_COLOR = 'black'

--- a/src/constants.py
+++ b/src/constants.py
@@ -84,7 +84,8 @@ K_SHOW_CURSOR_LABEL = ['show cursor label', 'SHOW_CURSOR_LABEL', None, False]
 
 K_MODEL_FOLDER = ['model folder', "P1_MODEL_FOLDER",
                   "P2_MODEL_FOLDER", "../model/pb", "../model/pb"]
-K_HEATMAP = ['Heatmap']
+K_HEATMAP = ['Heatmap', 'HEATMAP']
+K_SHOW_POLICY = ['Show policy', 'SHOW_POLICY', True]
 
 
 # non-setting keys
@@ -144,6 +145,7 @@ TAB_LABEL_PLAYER2 = "Player &2"
 
 # shortcut events for checkboxes
 EVENT_SHORTCUT_HEATMAP = 'SHORTCUT_HEATMAP'
+EVENT_SHORTCUT_SHOW_POLICY = 'SHORTCUT_SHOW_POLICY'
 EVENT_SHORTCUT_AUTOMOVE_1 = 'SHORTCUT_AUTOMOVE_1'
 EVENT_SHORTCUT_AUTOMOVE_2 = 'SHORTCUT_AUTOMOVE_2'
 EVENT_SHORTCUT_TRIALS_1_PLUS = 'SHORTCUT_TRIALS_1_PLUS'

--- a/src/constants.py
+++ b/src/constants.py
@@ -21,7 +21,6 @@ OUTPUT_TEXT_COLOR = "white"
 COLOR_LIST = ["black", "blue", "cyan", "orange",
               "lightgreen", "purple", "red", "yellow", "white"]
 FIELD_BACKGROUND_COLOR = "lightgrey"
-SHOW_LAST_MOVE = [True, 'yellow', 2]  # bool: show/don't show, border color, border size
 
 
 HEATMAP_CIRCLE_COLOR = 'black'

--- a/src/layout.py
+++ b/src/layout.py
@@ -124,6 +124,13 @@ def row_moves():
                          key=ct.K_MOVES[1], disabled=True, size=(28, 6))]
 
 
+def row_show_policy():
+    return [text_label(ct.K_SHOW_POLICY[0]),
+            sg.Checkbox(
+        text="", enable_events=True, default=ct.K_SHOW_POLICY[2],
+        key=ct.K_SHOW_POLICY[1],  size=(7 + ct.OFFSET, 1))]
+
+
 def row_heatmap():
     return [text_label(ct.K_HEATMAP[0]),
             sg.Checkbox(
@@ -179,6 +186,7 @@ class MainWindowLayout():
                                  self.row_eval_num(),
                                  self.row_eval_hist(),
                                  self.row_eval_moves(),
+                                 row_show_policy(),
                                  row_heatmap(),
                                  row_trials(),
                                  row_visits(),

--- a/src/plot.py
+++ b/src/plot.py
@@ -75,14 +75,13 @@ class EvalHistPlot():
             ax1.bar(values.keys(), values.values(),
                     color=list(map(self.sc_to_color, values.values())))
 
+            xmax = max(10, len(values))
+            plt.xlim(-1, xmax)
+            plt.xticks(np.arange(0, xmax, xmax // 6))
+            plt.ylim([-1, 1])
+
         plt.subplots_adjust(left=None, bottom=0.3,
                             right=None, top=0.9, wspace=0, hspace=0)
-
-        xmax = max(10, len(values))
-        plt.xlim(-1, xmax)
-        plt.xticks(np.arange(0, xmax, xmax // 6))
-        plt.ylim([-1, 1])
-
         self.agg.draw()
 
     def prepare(self, canvas):

--- a/src/tbui.py
+++ b/src/tbui.py
@@ -93,6 +93,7 @@ class TwixtbotUI():
         self.window.bind('<Alt-g>', ct.B_RESIGN)
         self.window.bind('<Alt-r>', ct.B_RESET)
         self.window.bind('<Alt-m>', ct.EVENT_SHORTCUT_HEATMAP)
+        self.window.bind('<Alt-p>', ct.EVENT_SHORTCUT_SHOW_POLICY)
         self.window.bind('<Alt-KeyPress-1>', ct.EVENT_SHORTCUT_AUTOMOVE_1)
         self.window.bind('<Alt-KeyPress-2>', ct.EVENT_SHORTCUT_AUTOMOVE_2)
         self.window.bind('<Alt-Right->', ct.EVENT_SHORTCUT_TRIALS_1_PLUS)
@@ -193,7 +194,18 @@ class TwixtbotUI():
 
         return sc, moves, P
 
+    def clear_evals(self):
+        self.get_control(ct.K_EVAL_NUM).Update('')
+        self.get_control(ct.K_EVAL_BAR).Update(0)
+        self.eval_moves_plot.update()
+        self.eval_hist_plot.update()
+        self.visit_plot.update()
+
     def update_evals(self):
+        if not self.get_control(ct.K_SHOW_POLICY).get():
+            self.clear_evals()
+            return
+
         if not self.game_over(False):
             sc, moves, P = self.calc_eval()
 
@@ -263,7 +275,9 @@ class TwixtbotUI():
 
         self.update_turn_indicators()
         self.update_history()
-        self.update_evals()
+        
+        if self.get_control(ct.K_SHOW_POLICY).get():
+            self.update_evals()
 
     def update_settings_changed(self):
         self.board.draw()
@@ -643,9 +657,14 @@ class TwixtbotUI():
             self.update_bots()
             return
 
-        # click on heatmap (no short
+        # click on heatmap (no shortcuts)
         if event == ct.K_HEATMAP[1]:
             self.update_after_move()
+            return
+
+        # click on show_policy (no shortcuts)
+        if event == ct.K_SHOW_POLICY[1]:
+            self.update_evals()
             return
 
         # thread events


### PR DESCRIPTION
Implements hiding policy stats (#47).
This allows the player(s) to play a game of Twixt without being influenced/distracted by the Alpha Zero bot input.