### PR TITLE
Ask to set crossing lines after opening tsgf file (#28)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "cwd": "${fileDirname}",
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/src/files.py
+++ b/src/files.py
@@ -2,7 +2,6 @@ import PySimpleGUI as sg
 from backend import twixt
 import layout as lt
 import string
-import settings as st
 
 
 
@@ -159,7 +158,7 @@ def parse_tsgf_file(content):
     return players, moves
 
 
-def get_game():
+def get_game(curent_cross_lines_setting=False):
     """Returns (players, moves) from a file, chosen by the user
 
     Shows a file-open dialog to the user.
@@ -175,7 +174,7 @@ def get_game():
     are handled within this function.
 
     Args:
-        None
+        curent_cross_lines_setting (bool): current setting for crossing lines
 
     Returns:
         tuple: (list: players as strings,
@@ -206,12 +205,12 @@ def get_game():
         if file_name[-2:].upper() == 'T1':
             return parse_t1_file(content), False
         elif file_name[-4:].lower() == 'tsgf':
-            if not stgs.get(ct.K_ALLOW_SCL[1]):
+            if not curent_cross_lines_setting:
                 enable_crossing_lines = sg.popup_yes_no(
                     "You have opened a .tsgf file, which propably comes "
                     "from LittleGolem. By default, LittleGolem allows "
                     "crossing lines. You don't have crossing lines enabled. "
-                    "Do you want to enable crossing lines?"
+                    "Do you want to enable crossing lines?",
                     title='Enable crossing lines?') == "Yes"
             return parse_tsgf_file(content), enable_crossing_lines
         else:

--- a/src/files.py
+++ b/src/files.py
@@ -2,6 +2,8 @@ import PySimpleGUI as sg
 from backend import twixt
 import layout as lt
 import string
+import settings as st
+
 
 
 
@@ -162,7 +164,13 @@ def get_game():
 
     Shows a file-open dialog to the user.
     The chosen file is read and parsed into players and moves.
+    If the file is a tsgf file, the user is asked if the setting
+    to allow crossing lines should be enabled, because Little Golem
+    plays with corring lines allowed by default.
     The resulting player name list and moves list is returned.
+    Finally a boolean is returned, which indicates if crossing lines
+    should be set to enabled (True) or if it should be left
+    in the current state (False).
     Exceptions that occur while opening and/or parsing the file
     are handled within this function.
 
@@ -170,8 +178,11 @@ def get_game():
         None
 
     Returns:
-        tuple: (list: players as strings, list: twixt moves)
+        tuple: (list: players as strings,
+                list: twixt moves,
+                bool: enable_crossing_lines)
     """
+    RETURN_ON_FAILURE = (None, None, False)
 
     # Get filename
     file_name = sg.PopupGetFile('Choose file', file_types=(
@@ -180,7 +191,7 @@ def get_game():
         ("Little Golem Files", "*.tsgf")), no_window=True, keep_on_top=True)
 
     if file_name is None or file_name == "":
-        return None, None
+        return RETURN_ON_FAILURE
 
     # Open file
     try:
@@ -188,20 +199,27 @@ def get_game():
             content = list(map(lambda s: s.strip(), f.readlines()))
     except Exception:
         sg.popup_ok(f"Can't open {file_name} as a valid Twixt file.")
-        return None, None
+        return RETURN_ON_FAILURE
 
     # Parse file
     try:
         if file_name[-2:].upper() == 'T1':
-            return parse_t1_file(content)
+            return parse_t1_file(content), False
         elif file_name[-4:].lower() == 'tsgf':
-            return parse_tsgf_file(content)
+            if not stgs.get(ct.K_ALLOW_SCL[1]):
+                enable_crossing_lines = sg.popup_yes_no(
+                    "You have opened a .tsgf file, which propably comes "
+                    "from LittleGolem. By default, LittleGolem allows "
+                    "crossing lines. You don't have crossing lines enabled. "
+                    "Do you want to enable crossing lines?"
+                    title='Enable crossing lines?') == "Yes"
+            return parse_tsgf_file(content), enable_crossing_lines
         else:
             lt.popup("Didn't recognize the filename extension.")
     except Exception as e:
         sg.popup_ok(f"Error '{e}' while opening file {file_name}")
 
-    return None, None
+    return RETURN_ON_FAILURE
 
 
 def save_game(players=['Player1', 'Player2'],

--- a/src/files.py
+++ b/src/files.py
@@ -205,6 +205,7 @@ def get_game(curent_cross_lines_setting=False):
         if file_name[-2:].upper() == 'T1':
             return parse_t1_file(content), False
         elif file_name[-4:].lower() == 'tsgf':
+            enable_crossing_lines = False
             if not curent_cross_lines_setting:
                 enable_crossing_lines = sg.popup_yes_no(
                     "You have opened a .tsgf file, which propably comes "
@@ -212,7 +213,7 @@ def get_game(curent_cross_lines_setting=False):
                     "crossing lines. You don't have crossing lines enabled. "
                     "Do you want to enable crossing lines?",
                     title='Enable crossing lines?') == "Yes"
-            return parse_tsgf_file(content), enable_crossing_lines
+            return *parse_tsgf_file(content), enable_crossing_lines
         else:
             lt.popup("Didn't recognize the filename extension.")
     except Exception as e:

--- a/src/tbui.py
+++ b/src/tbui.py
@@ -393,16 +393,20 @@ class TwixtbotUI():
             self.update_after_move(False)
 
     def handle_open_file(self):
-        players, moves = fi.get_game()
+        players, moves, cross_lines = fi.get_game()
         if players is None:
             return
 
         # assign player names
         self.stgs.settings[ct.K_NAME[1]] = players[0]
         self.stgs.settings[ct.K_NAME[2]] = players[1]
+
+        # adjust settings if needed
+        if cross_lines:
+            self.stgs.set(ct.K_ALLOW_SCL[1], True)
         self.update_settings_changed()
 
-        # reset game
+        # reset game (which also handles changes crossing lines settings)
         self.reset_game()
 
         # replay game

--- a/src/tbui.py
+++ b/src/tbui.py
@@ -393,7 +393,7 @@ class TwixtbotUI():
             self.update_after_move(False)
 
     def handle_open_file(self):
-        players, moves, cross_lines = fi.get_game()
+        players, moves, x_lines = fi.get_game(self.stgs.get(ct.K_ALLOW_SCL[1]))
         if players is None:
             return
 
@@ -402,7 +402,7 @@ class TwixtbotUI():
         self.stgs.settings[ct.K_NAME[2]] = players[1]
 
         # adjust settings if needed
-        if cross_lines:
+        if x_lines:
             self.stgs.set(ct.K_ALLOW_SCL[1], True)
         self.update_settings_changed()
 


### PR DESCRIPTION
Only asks user to enable crossing lines if relevant (when crossing lines are off and tsgf file is opened). User can choose to set crossing lines or leave it off.