### PR TITLE
Resign Threshold / Bugfix ETA / refactored non-MCTS play

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,8 @@ config.json
 
 pkginfo
 pynsist_pkgs/
+
+
+profile.py
+out.txt
+src/profile.cmd

--- a/README.md
+++ b/README.md
@@ -116,8 +116,7 @@ Parameters *auto move* and *trials* can also be changed in the control panel of 
 + *show cursor label*: display the coordinates in a tooltip at the mouse cursor (default: false)
 + *highlight last move*: display a yellow circle around last peg (default: false)
 + *smart accept*: during MCTS, reduce the max number of trials automatically according to the lead of the best move (default: true)
-+ *resign threshold*: if evaluation is bigger than this threshold - in favor of the opponent - the bot will resign (default: 0.95)
-
++ *resign threshold*: if opponent's evaluation is bigger than this threshold the bot will resign (default: 0.95)
 + *log level*: verbosity of log messages (default: ERROR)
 
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Parameters *auto move* and *trials* can also be changed in the control panel of 
 + *show cursor label*: display the coordinates in a tooltip at the mouse cursor (default: false)
 + *highlight last move*: display a yellow circle around last peg (default: false)
 + *smart accept*: during MCTS, reduce the max number of trials automatically according to the lead of the best move (default: true)
++ *resign threshold*: if evaluation is bigger than this threshold - in favor of the opponent - the bot will resign (default: 0.95)
+
 + *log level*: verbosity of log messages (default: ERROR)
 
 

--- a/src/backend/twixt.py
+++ b/src/backend/twixt.py
@@ -192,7 +192,7 @@ class Game:
         return copy
 
     def turn_to_player(self, turn=None):
-        if turn or turn == 0:
+        if turn is not None or turn == 0:
             return 2 - turn
         else:
             return 2 - self.turn

--- a/src/constants.py
+++ b/src/constants.py
@@ -63,57 +63,62 @@ TEMPERATURE_LIST = [0.0, 0.5, 1.0]
 
 LOG_LEVEL_LIST = list(map(logging.getLevelName, range(10, 60, 10)))
 
-# keys
+# keys - player 1/2
 K_COLOR = ['color', 'P1_COLOR', 'P2_COLOR', "red", "black"]
-K_TURN_INDICATOR = ['turn', 'P1_TURN_INDICATOR',
-                    'P2_TURN_INDICATOR', TURN_CHAR, ""]
 K_NAME = ['name', 'P1_NAME', 'P2_NAME', "Tom", "Jerry"]
 K_AUTO_MOVE = ['auto move', 'P1_AUTO_MOVE', 'P2_AUTO_MOVE', False, False]
-K_TRIALS = ['trials', 'P1_TRIALS', 'P2_TRIALS', 0, 0]
-K_VISUALIZE_MCTS = ['visualize', 'VISUALIZE_MCTS', None, False]
-K_ALLOW_SWAP = ['allow swap', 'ALLOW_SWAP', None, True]
-K_ALLOW_SCL = ['allow self crossing links', 'ALLOW_SCL', None, False]
-K_SMART_ACCEPT = ['smart accept', 'SMART_ACCEPT', None, True]
-K_SMART_ROOT = ['smart root', 'P1_SMART_ROOT',
-                'P2_SMART_ROOT', False, False]
-
-K_TEMPERATURE = ['temperature', 'P1_TEMPERATURE', 'P2_TEMPERATURE', 0.0, 0.0]
-K_CPUCT = ['cpuct', 'P1_CPUCT', 'P2_CPUCT', 1.0, 1.0]
+K_MODEL_FOLDER = ['model folder', "P1_MODEL_FOLDER",
+                  "P2_MODEL_FOLDER", "../model/pb", "../model/pb"]
 K_RANDOM_ROTATION = ['random rotation',
                      'P1_RANDOM_ROTATION', 'P2_RANDOM_ROTATION', False, False]
+K_TRIALS = ['trials', 'P1_TRIALS', 'P2_TRIALS', 0, 0]
+K_SMART_ROOT = ['smart root', 'P1_SMART_ROOT',
+                'P2_SMART_ROOT', False, False]
+K_TEMPERATURE = ['temperature', 'P1_TEMPERATURE', 'P2_TEMPERATURE', 0.0, 0.0]
+K_CPUCT = ['cpuct', 'P1_CPUCT', 'P2_CPUCT', 1.0, 1.0]
 K_ADD_NOISE = ['add noise', 'P1_ADD_NOISE', 'P2_ADD_NOISE', 0.0, 0.0]
+
+# keys - general
+K_ALLOW_SWAP = ['allow swap', 'ALLOW_SWAP', None, True]
+K_ALLOW_SCL = ['allow self crossing links', 'ALLOW_SCL', None, False]
 K_BOARD_SIZE = ['board size (pixels)', 'BOARD_SIZE', None, 600]
 K_SHOW_LABELS = ['show labels', 'SHOW_LABELS', None, True]
 K_SHOW_GUIDELINES = ['show guidelines', 'SHOW_GUIDELINES', None, False]
 K_SHOW_CURSOR_LABEL = ['show cursor label', 'SHOW_CURSOR_LABEL', None, False]
 K_HIGHLIGHT_LAST_MOVE = ['highlight last move',
                          'HIGHLIGHT_LAST_MOVE', None, False]
-K_MODEL_FOLDER = ['model folder', "P1_MODEL_FOLDER",
-                  "P2_MODEL_FOLDER", "../model/pb", "../model/pb"]
+K_SMART_ACCEPT = ['smart accept', 'SMART_ACCEPT', None, True]
+K_RESIGN_THRESHOLD = ['resign threshold', 'RESIGN_THRESHOLD', None, 0.95]
+
 K_LOG_LEVEL = ['Log level', 'LOG_LEVEL', None, logging.getLevelName(logging.ERROR)]
 
-# non-setting keys
-K_SHOW_EVALUATION = ['', 'SHOW_EVALUATION', None, True]
+# keys - non-setting
+K_BOARD = [None, 'BOARD']
 K_EVAL_BAR = ['', 'EVAL_BAR', None, 0]
+K_TURN_INDICATOR = ['turn', 'P1_TURN_INDICATOR',
+                    'P2_TURN_INDICATOR', TURN_CHAR, ""]
+K_MOVES = ['moves', 'MOVES']
+K_SHOW_EVALUATION = ['', 'SHOW_EVALUATION', None, True]
 K_EVAL_NUM = ['', 'EVAL_NUM', None, ""]
+K_EVAL_HIST = ['history', 'EVAL_HIST']
 K_EVAL_MOVES = ['P * 1000', 'EVAL_MOVES', None, ""]
 K_HEATMAP = ['heatmap', 'HEATMAP']
-K_EVAL_HIST = ['history', 'EVAL_HIST']
-K_SPLASH_PROGRESS_BAR = ['SPLASH_PROGRESS_BAR']
-K_SPLASH_STATUS_TEXT = ['SPLASH_STATUS_TEXT']
+
+K_VISITS = ['visits', 'VISITS']
+K_VISUALIZE_MCTS = ['visualize', 'VISUALIZE_MCTS', None, False]
 K_PROGRESS_BAR = ['progress', 'PROGRESS_BAR']
 K_PROGRESS_NUM = ['', 'PROGRESS_NUMBERS']
 K_SPINNER = ['', 'SPINNER']
-K_VISITS = ['visits', 'VISITS']
-K_MOVES = ['moves', 'MOVES']
-K_BOARD = [None, 'BOARD']
+
+K_SPLASH_PROGRESS_BAR = ['SPLASH_PROGRESS_BAR']
+K_SPLASH_STATUS_TEXT = ['SPLASH_STATUS_TEXT']
 K_THREAD = [None, 'THREAD']
 
 
 SETTING_KEYS = [K_ALLOW_SWAP, K_ALLOW_SCL, K_SMART_ACCEPT,
                 K_COLOR, K_NAME, K_AUTO_MOVE, K_TRIALS, K_MODEL_FOLDER,
                 K_TEMPERATURE, K_CPUCT, K_ADD_NOISE, K_RANDOM_ROTATION,
-                K_BOARD_SIZE, K_LOG_LEVEL, K_SMART_ROOT,
+                K_BOARD_SIZE, K_LOG_LEVEL, K_SMART_ROOT, K_RESIGN_THRESHOLD,
                 K_SHOW_LABELS, K_SHOW_GUIDELINES, K_SHOW_CURSOR_LABEL, K_HIGHLIGHT_LAST_MOVE]
 
 

--- a/src/layout.py
+++ b/src/layout.py
@@ -243,6 +243,12 @@ def st_row_smart_accept():
     return [st_label(ct.K_SMART_ACCEPT[0]), sg.Checkbox(text="", default=ct.K_SMART_ACCEPT[3], key=ct.K_SMART_ACCEPT[1])]
 
 
+def st_row_resign_threshold():
+    return [st_label(ct.K_RESIGN_THRESHOLD[0]),
+            sg.Spin(values=[float((x + 70.0) / 100.0) for x in range(31)],
+                    initial_value=ct.K_RESIGN_THRESHOLD[3], key=ct.K_RESIGN_THRESHOLD[1], size=(5, 0))]
+
+
 def st_row_color(player):
     return [st_label(ct.K_COLOR[0]),
             sg.Combo(ct.COLOR_LIST, ct.K_COLOR[player + 2],
@@ -343,6 +349,7 @@ class SettingsDialogLayout():
                            sg.Checkbox(text=None, default=ct.K_HIGHLIGHT_LAST_MOVE[3], key=ct.K_HIGHLIGHT_LAST_MOVE[1])],
                           row_separator(""),
                           st_row_smart_accept(),
+                          st_row_resign_threshold(),
                           row_separator(""),
                           [st_label(ct.K_LOG_LEVEL[0]),
                            sg.Combo(ct.LOG_LEVEL_LIST, ct.K_LOG_LEVEL[3], size=(

--- a/src/tbui.py
+++ b/src/tbui.py
@@ -64,6 +64,7 @@ class TwixtbotUI():
         self.stgs = stgs
         self.bot_event = None
         self.redo_moves = []
+        self.next_move = None
         self.logger = logging.getLogger(ct.LOGGER)
 
         # Setup main GUI window
@@ -201,6 +202,7 @@ class TwixtbotUI():
         score, moves, P = self.bots[self.game.turn].nm.eval_game(self.game)
         # get score from white's perspective
         sc = round((2 * self.game.turn - 1) * score, 3)
+        self.next_move = sc, moves, P        
         # Add sc to dict of historical scores
         self.moves_score[len(self.game.history)] = sc
 
@@ -216,6 +218,7 @@ class TwixtbotUI():
     def update_evals(self):
         if not self.get_control(ct.K_SHOW_EVALUATION).get():
             self.clear_evals()
+            self.next_move = None
             return
 
         if not self.game_over(False):
@@ -231,7 +234,8 @@ class TwixtbotUI():
         else:
             self.get_control(ct.K_EVAL_NUM).Update('')
             self.get_control(ct.K_EVAL_BAR).Update(0)
-
+            self.next_move = None
+            
         # clean visits
         self.visit_plot.update()
         self.eval_hist_plot.update(self.moves_score)
@@ -369,8 +373,21 @@ class TwixtbotUI():
         import backend.nnmplayer as nnmplayer
         self.bots[2 - player] = nnmplayer.Player(**args)
 
-    def bot_move(self):
-        response = self.bots[self.game.turn].pick_move(self.game, self.window, self.bot_event)
+    def call_bot_and_move(self):
+        if len(self.game.history) >= 2 and self.get_current(ct.K_TRIALS) == 0 and self.next_move is not None:
+            # we already have the next move from evaluation
+            
+            # self.bots[self.game.turn].nm.send_message(self.window, self.game, "done",
+            #                                          0, 0, moves=self.next_move[1], P=self.next_move[2])
+            response = {
+                "status": "done",
+                "moves": self.next_move[1],
+                "P": self.next_move[2]
+            }
+            
+        else:
+            # mcts, or first/second move       
+            response = self.bots[self.game.turn].pick_move(self.game, self.window, self.bot_event)
 
         if response["status"] == "done":
             self.get_control(ct.K_SPINNER).Update(visible=False)
@@ -395,7 +412,7 @@ class TwixtbotUI():
         self.window[ct.K_SPINNER[1]].Update(visible=True)
         self.bot_event = BotEvent()
         self.thread = threading.Thread(
-            target=self.bot_move, args=(), daemon=True)
+            target=self.call_bot_and_move, args=(), daemon=True)
 
         self.timer = pmeter.ETA(100.0, max_seconds=20)
         self.thread.start()
@@ -541,6 +558,17 @@ class TwixtbotUI():
         #self.board.create_move_objects(len(self.game.history) - 1)
         self.game_over()
 
+    def bot_move(self):
+        if not self.game_over():
+            # clear move statistics
+            self.visit_plot.update()
+            self.update_progress()
+            if (-2 * self.game.turn + 1) * self.next_move[0] > self.stgs.get(ct.K_RESIGN_THRESHOLD[1]):
+                self.execute_move(twixt.RESIGN)
+                # check resign-threshold
+            else: 
+                self.launch_bot()
+
     def create_settings_window(self):
 
         sd = lt.SettingsDialogLayout()
@@ -614,11 +642,7 @@ class TwixtbotUI():
 
     def handle_button_event(self, event, values):
         if event == ct.B_BOT_MOVE:
-            if not self.game_over():
-                # clear move statistics
-                self.visit_plot.update()
-                self.update_progress()
-                self.launch_bot()
+            self.bot_move()
             return True
 
         if event == ct.B_UNDO:
@@ -776,11 +800,9 @@ def main():
 
     # Event Loop
     while True:
-        if not ui.game_over(False) and ui.get_current(ct.K_AUTO_MOVE):
-            # auto move case
-            if not ui.thread_is_alive():
-                ui.update_progress()
-                ui.launch_bot()
+        if ui.get_current(ct.K_AUTO_MOVE) and not ui.thread_is_alive():
+            ui.update_progress()
+            ui.bot_move()
 
         event, values = ui.get_event()
         

--- a/src/tbui.py
+++ b/src/tbui.py
@@ -270,7 +270,6 @@ class TwixtbotUI():
             text = str(value) + "/" + str(max_value) + "      " + \
                 str(round(100 * value / max_value)) + "%      "
                 
-            print("value", value, "values['max']", values["max"], "max_value", max_value)
             v = 100.0 * (value + values["max"] - max_value) / values["max"]
             self.timer.update(v)
             text += self.timer.getstatus()

--- a/src/util/pmeter.py
+++ b/src/util/pmeter.py
@@ -14,7 +14,7 @@ __source__ = 'http://code.activestate.com/recipes/577002-precise-console-progres
 
 
 def format_sec(sec):
-    sec = int(sec)
+    sec = round(sec)
     min_, sec = divmod(sec, 60)
     hour, min_ = divmod(min_, 60)
     return '%d:%02d:%02d' % (hour, min_, sec)
@@ -63,7 +63,6 @@ class ETA(object):
             return
 
         eta = (float(self.wanted_size) - float(cursize)) / float(speed)
-        print("eta", eta, "cursize", cursize)
         self.eta = format_sec(eta)
 
     def getstatus(self):
@@ -103,7 +102,6 @@ class ProgressMeter(object):
     def set_complete(self):
         self.needrefresh = 1
         self.update(self.size)
-        print  # left progress bar on screen
 
     def _rawupdate(self, cursize):
         self.eta_calculator.update(cursize)

--- a/src/util/pmeter.py
+++ b/src/util/pmeter.py
@@ -63,6 +63,7 @@ class ETA(object):
             return
 
         eta = (float(self.wanted_size) - float(cursize)) / float(speed)
+        print("eta", eta, "cursize", cursize)
         self.eta = format_sec(eta)
 
     def getstatus(self):


### PR DESCRIPTION
- bots resign now if game is lost, i.e. if opponent's eval is bigger than a configurable threshold - by default 0.95
- there was a bug in ETA calculation that led to negative remining times
- if trials==0 (no MCTS) a sync call to the bot's evaluation function is done (no threading) and there is less UI refreshing which leads to quicker self-play
-  