### PR TITLE
Bugfix/segmentation fault

### DIFF
--- a/installer.cfg
+++ b/installer.cfg
@@ -1,7 +1,7 @@
 [Application]
 
 name=twixtbot-ui
-version=2021-05-19
+version=2021-05-25
 script=winlaunch.py
 console=true
 publisher=stevens68

--- a/installer.cfg
+++ b/installer.cfg
@@ -1,7 +1,7 @@
 [Application]
 
 name=twixtbot-ui
-version=2021-05-14
+version=2021-05-19
 script=winlaunch.py
 console=true
 publisher=stevens68

--- a/src/backend/nnmcts.py
+++ b/src/backend/nnmcts.py
@@ -142,7 +142,7 @@ class NeuralMCTS:
         move = naf.policy_index_point(game.turn, index)
 
         if top:
-            self.logger.info("selecting index=%d move=%s Q=%.3f P=%.5f N=%d",
+            self.logger.debug("selecting index=%d move=%s Q=%.3f P=%.5f N=%d",
                              index, str(move), node.Q[index], node.P[index], node.N[index])
 
         subnode = node.subnodes[index]
@@ -306,8 +306,8 @@ class NeuralMCTS:
         if self.root.proven:
             return self.proven_result(game)
 
-        self.logger.info("N=%s", self.root.N)
-        self.logger.info("Q=%s", self.root.Q)
+        self.logger.debug("N=%s", self.root.N)
+        self.logger.debug("Q=%s", self.root.Q)
 
         self.report = "%6.3f" % (
             self.root.Q[numpy.argmax(self.root.N)]) + self.top_moves_str(game)

--- a/src/backend/nnmplayer.py
+++ b/src/backend/nnmplayer.py
@@ -102,7 +102,7 @@ class Player:
             weights = N
         elif self.temperature == 0.5:
             weights = N ** 2
-        self.logger.info("weights=%s", weights)
+        self.logger.debug("weights=%s", weights)
         index = numpy.random.choice(numpy.arange(
             len(weights)), p=weights / weights.sum())
         

--- a/src/constants.py
+++ b/src/constants.py
@@ -167,6 +167,8 @@ EVENT_SHORTCUT_TRIALS_2_MINUS = 'SHORTCUT_TRIALS_2_MINUS'
 
 EVENT_EXIT = "Exit"
 
+EVENT_UPDATE_UI = "UpdateUI"
+
 # Logging
 LOGGER = 'twixtbot-ui'
 LOG_FORMAT = '[%(levelname)s] [%(asctime)s] [%(filename)s:(%(lineno)d] %(message)s'

--- a/src/constants.py
+++ b/src/constants.py
@@ -167,8 +167,6 @@ EVENT_SHORTCUT_TRIALS_2_MINUS = 'SHORTCUT_TRIALS_2_MINUS'
 
 EVENT_EXIT = "Exit"
 
-EVENT_UPDATE_UI = "UpdateUI"
-
 # Logging
 LOGGER = 'twixtbot-ui'
 LOG_FORMAT = '[%(levelname)s] [%(asctime)s] [%(filename)s:(%(lineno)d] %(message)s'

--- a/src/tbui.py
+++ b/src/tbui.py
@@ -495,13 +495,19 @@ class TwixtbotUI():
             self.handle_accept_bot()
         elif event == ct.B_CANCEL:
             self.handle_cancel_bot()
-        elif event in [ct.K_BOARD[1], ct.B_UNDO, ct.B_REDO, ct.B_RESIGN, ct.B_RESET, ct.B_BOT_MOVE, ct.K_VISUALIZE_MCTS[1], ct.K_HEATMAP[1],
-                        ct.EVENT_SHORTCUT_VISUALIZE_MCTS, ct.EVENT_SHORTCUT_HEATMAP]:
+        elif event in [ct.K_BOARD[1],
+                       ct.B_UNDO, ct.B_REDO, ct.B_RESIGN, ct.B_RESET, ct.B_BOT_MOVE,
+                       ct.K_VISUALIZE_MCTS[1], ct.EVENT_SHORTCUT_VISUALIZE_MCTS,
+                       ct.K_HEATMAP[1], ct.EVENT_SHORTCUT_HEATMAP,
+                       ct.K_SHOW_EVALUATION[1], ct.EVENT_SHORTCUT_SHOW_EVALUATION]:
             lt.popup("bot in progress. Click Accept or Cancel.")
+            # undo checkbox change
             if event == ct.K_VISUALIZE_MCTS[1]:
                 self.get_control(ct.K_VISUALIZE_MCTS).update(not self.get_control(ct.K_VISUALIZE_MCTS).get())
             elif event == ct.K_HEATMAP[1]:
                 self.get_control(ct.K_HEATMAP).update(not self.get_control(ct.K_HEATMAP).get())
+            elif event == ct.K_SHOW_EVALUATION[1]:
+                self.get_control(ct.K_SHOW_EVALUATION).update(not self.get_control(ct.K_SHOW_EVALUATION).get())
  
     def thread_is_alive(self):
         return hasattr(self, 'thread') and self.thread is not None and self.thread.is_alive()
@@ -730,13 +736,6 @@ class TwixtbotUI():
             self.update_bots()
             return
 
-
-        # click on evaluation checkbox (no shortcuts)
-        if event == ct.K_SHOW_EVALUATION[1]:
-            self.update_evals()
-            return
-
-
         # thread events
         if event == ct.K_THREAD[1]:
             # handle event sent from bot
@@ -760,6 +759,11 @@ class TwixtbotUI():
         # selection of mcts visualization
         if event == ct.K_VISUALIZE_MCTS[1]:
             self.update_bots()
+            return
+
+        # click on evaluation checkbox (no shortcuts)
+        if event == ct.K_SHOW_EVALUATION[1]:
+            self.update_evals()
             return
 
         # click on heatmap (no shortcuts)

--- a/src/tbui.py
+++ b/src/tbui.py
@@ -388,22 +388,14 @@ class TwixtbotUI():
             response = self.bots[self.game.turn].pick_move(self.game, self.window, self.bot_event)
 
         if response["status"] == "done":
-            self.get_control(ct.K_SPINNER).Update(visible=False)
             if self.bot_event is None or not self.bot_event.is_set() or self.bot_event.get_context() == ct.ACCEPT_EVENT:
                 # bot has not been cancelled (but is finished or accepted)
                 self.execute_move(response["moves"][0])
-                self.update_after_move(False)
+                # self.window.write_event_value(ct.EVENT_UPDATE_UI, None)
             else:
-                # bot has been cancelled clear progress controls and visits
-                self.update_progress()
                 # reset history_at_root resets tree and visit counts
                 self.bots[self.game.turn].nm.history_at_root = None
 
-                # switch off auto move
-                if self.get_current(ct.K_AUTO_MOVE):
-                    self.set_current(ct.K_AUTO_MOVE, False)
-                    self.get_control(
-                        ct.K_AUTO_MOVE, self.game.turn_to_player()).Update(False)
 
     def launch_bot(self):
         
@@ -727,9 +719,20 @@ class TwixtbotUI():
             return update_slider(2, max, 0, -1)
 
         return False
+    
+    def handle_update_ui_event(self, event, values):
+        if event == ct.EVENT_UPDATE_UI:
+            self.get_control(ct.K_SPINNER).Update(visible=False)
+            self.update_after_move(False)            
+            return True
+        return False
 
     def handle_event(self, event, values):
 
+        
+        if self.handle_update_ui_event(event, values):
+            return
+        
         # menue events
         if self.handle_menue_event(event, values):
             return

--- a/src/tbui.py
+++ b/src/tbui.py
@@ -473,13 +473,12 @@ class TwixtbotUI():
         self.bot_event.set(ct.ACCEPT_EVENT)
 
     def handle_cancel_bot(self):
-        print("current player", self.game.turn_to_player())
         self.bot_event.set(ct.CANCEL_EVENT)
         # switch off auto move
-        if self.get_current(ct.K_AUTO_MOVE):
-            print("switching off auto-move for", self.game.turn_to_player())
-            self.set_current(ct.K_AUTO_MOVE, False)
-            self.get_control(ct.K_AUTO_MOVE, self.game.turn_to_player()).Update(False)
+        # (do not use self.game.turn_to_player() to determine current player during mcts)
+        p = 1 if self.get_control(ct.K_TURN_INDICATOR, 1).get() == ct.TURN_CHAR else 2
+        self.stgs.set(ct.K_AUTO_MOVE[p], False)
+        self.get_control(ct.K_AUTO_MOVE, p).Update(False)
 
     def handle_thread_event(self, values):
         self.logger.info("Bot response: %s", values)

--- a/src/tbui.py
+++ b/src/tbui.py
@@ -232,12 +232,6 @@ class TwixtbotUI():
             values = {"moves": moves, "Y": P}
             self.eval_moves_plot.update(values, 1000)
 
-        """
-        else:
-            self.get_control(ct.K_EVAL_NUM).Update('')
-            self.get_control(ct.K_EVAL_BAR).Update(0)
-        """    
-        self.next_move = None
         # clean visits
         self.visit_plot.update()
         self.eval_hist_plot.update(self.moves_score)
@@ -479,12 +473,13 @@ class TwixtbotUI():
         self.bot_event.set(ct.ACCEPT_EVENT)
 
     def handle_cancel_bot(self):
+        print("current player", self.game.turn_to_player())
         self.bot_event.set(ct.CANCEL_EVENT)
         # switch off auto move
         if self.get_current(ct.K_AUTO_MOVE):
+            print("switching off auto-move for", self.game.turn_to_player())
             self.set_current(ct.K_AUTO_MOVE, False)
-            self.get_control(
-                ct.K_AUTO_MOVE, self.game.turn_to_player()).Update(False)
+            self.get_control(ct.K_AUTO_MOVE, self.game.turn_to_player()).Update(False)
 
     def handle_thread_event(self, values):
         self.logger.info("Bot response: %s", values)


### PR DESCRIPTION
This PR fixes the segmentation fault caused by a window update inside and outside the mcts thread - which TKinter doesn't like.
(I hope it is fixed, as I could never reproduce it)
Before an mcts thread is started, an event is now set as a reminder to update the UI in the event loop after the thread has finished

Some minor bugfixes:
* click on evaluation during MCTS is now rejected
* auto move was not always set to false for the current player when cancelling mcts
* after the resign threshold was reached, "resigned" was not displayed in turn textbox    